### PR TITLE
Update gabbar pipeline to 0.0.23

### DIFF
--- a/01-gabbar/00-tekton-pipelines/00-build/Chart.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 dependencies:
   - name: pipeline-charts
     repository: https://stakater.github.io/stakater-charts
-    version: 0.0.22
+    version: 0.0.23
 description: Helm chart for Tekton Pipelines
 name: stakater-main-pr-v2
-version: 0.0.1
+version: 0.0.2

--- a/01-gabbar/00-tekton-pipelines/00-build/values.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/values.yaml
@@ -78,7 +78,6 @@ pipeline-charts:
       - taskName: stakater-push-main-tag-v1
   triggertemplate:
     serviceAccountName: stakater-tekton-builder
-    pipelineRunNamePrefix: $(tt.params.repoName)-branch-$(tt.params.gitbranch)
   eventlistener:
     serviceAccountName: stakater-tekton-builder
     triggers:

--- a/01-gabbar/00-tekton-pipelines/00-build/values.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/values.yaml
@@ -83,7 +83,7 @@ pipeline-charts:
              value: $(params.commit-id)
   triggertemplate:
     serviceAccountName: stakater-tekton-builder
-    pipelineRunNamePrefix: $(tt.params.repoName)-branch-$(tt.params.prnumberBranch)-$(tt.params.commit-id)
+    pipelineRunNamePrefix: $(tt.params.repoName)-$(tt.params.prnumberBranch)-$(tt.params.commit-id)
   eventlistener:
     serviceAccountName: stakater-tekton-builder
     triggers:


### PR DESCRIPTION
**Problem**  
PipelineRun Name using gitbranch has issues creating pipeline because branch name may have forbidden characters that couldnt be used in k8s resource names.  

**Findings**  
- CEL intercepter could help but it wasnt possible to define edge cases because regex replace wasnt supported.

- Revert to the old naming convention with pr number since branch names could have many forbidden character.  Issue in this convention was that :

  1. It was less readable.
  2. It makes more sense to have branch name. developer creates branch name himself while pr number is created automatically. it is easier to track pipeline by branch name
  3.  In case of master/main branch, it was showing <repo-name>-pr-main which does not make sense. Previously before pipeline-charts, pipeline run name used prnumberBranch parameter to use in pipelinerun name and had different values for pr ( value: pr-$(body.prnumber) ) and main ( value : main )bindings. But because pipeline chart will only define pipeline variables in trigger template variable we had to remove prnumberBranch parameter and use pr number.  
  
**Solution**  
- Revert to old convention. Support different name in case of PR and main branch, so in pr case, we can have pr-<pr-number> and in main we can say branch-main by adding support in pipeline chart for defining trigger template params. 
[Pipeline chart PR ](https://github.com/stakater/pipeline-charts/pull/39)
- Update pipeline chart version and remove pipelinerun prefix from values.yaml in gabbar (this pr) and nordmart-review-ui pipeline -> [pr-ref](https://github.com/stakater/nordmart-apps-gitops-config/pull/310) 