### PR TITLE
[gabbar-review-ui-build] Add parameter to e2e task 

### DIFF
--- a/01-gabbar/02-stakater-nordmart-review-ui/00-build/values.yaml
+++ b/01-gabbar/02-stakater-nordmart-review-ui/00-build/values.yaml
@@ -126,6 +126,8 @@ pipeline-charts:
         - name: timeout
           value: "180"
       - taskName: stakater-e2e-test-v1
+        params:
+          - name: namespace
   triggertemplate:
     serviceAccountName: stakater-tekton-builder
   eventlistener:


### PR DESCRIPTION
[gabbar-review-ui-build] Add parameter to e2e task 

We added a new parameter to e2e task namespace which wasnt specified causing the pipeline to fail 

https://console-openshift-console.apps.devtest.vxdqgl7u.kubeapp.cloud/k8s/ns/gabbar-build/tekton.dev~v1beta1~PipelineRun/stakater-nordmart-review-ui-pr-183-nq96n