### PR TITLE
Add 5 minutes timeout to app sync and wait

### DIFF
--- a/01-gabbar/00-tekton-pipelines/00-build/values.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/values.yaml
@@ -114,7 +114,7 @@ pipeline-charts:
       - taskName: stakater-app-sync-and-wait-v1
         params:
         - name: timeout
-          value: "120"
+          value: "300"
   triggertemplate:
     serviceAccountName: stakater-tekton-builder
     pipelineRunNamePrefix: $(tt.params.repoName)-$(tt.params.prnumberBranch)


### PR DESCRIPTION
Timeout for app sync and wait is 2 minutes.
Tronador takes longer to bring the env up therefore the task fails on 2 minutes timeout.

Increase the timeout to 5 mins to prevent it from failing.