### PR TITLE
Update app sync  timeout to 5 mins

### DIFF
--- a/01-gabbar/02-stakater-nordmart-review-ui/00-build/values.yaml
+++ b/01-gabbar/02-stakater-nordmart-review-ui/00-build/values.yaml
@@ -124,7 +124,7 @@ pipeline-charts:
       - taskName: stakater-app-sync-and-wait-v1
         params:
         - name: timeout
-          value: "180"
+          value: "300"
       - taskName: stakater-e2e-test-v1
         params:
           - name: namespace


### PR DESCRIPTION
App sync and wait timeout is only 3 minutes. Increase it to 5 mins