### PR TITLE
Fix chart order

### DIFF
--- a/01-gabbar/00-tekton-pipelines/00-build/values.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/values.yaml
@@ -91,6 +91,7 @@ stakater-tekton-chart:
       - defaultTaskName: stakater-comment-on-github-pr-v1
         runAfter:
         - stakater-trivy-scan-v1
+        - rox-deployment-check
         - rox-image-scan
         - rox-image-check
         - stakater-checkov-scan-v1


### PR DESCRIPTION
The comment on github task was not waiting for rox deployment check task messing up the task ordering in the pipeline.
Task ordering fixed in this PR. Now all security scans run in parallel.