### PR TITLE
Update Triggers for Pipeline SA 1936

### DIFF
--- a/01-gabbar/00-tekton-pipelines/00-build/values.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/values.yaml
@@ -111,24 +111,21 @@ stakater-tekton-chart:
     triggers:
     - name: stakater-pr-cleaner-v2-pullrequest-merge
       create: false
-    - name: pullrequest-create
-      create: true
+    - name: github-pullrequest-create
       bindings:
       - ref: stakater-pr-v1
       - name: oldcommit
         value: $(body.pull_request.base.sha)
       - name: newcommit
         value: $(body.pull_request.head.sha)
-    - name: pullrequest-synchronize
-      create: true
+    - name: github-pullrequest-synchronize
       bindings:
         - ref: stakater-pr-v1
         - name: oldcommit
           value: $(body.before)
         - name: newcommit
           value: $(body.after)
-    - name: push
-      create: true
+    - name: github-push
       bindings:
         - ref: stakater-main-v1
         - name: oldcommit


### PR DESCRIPTION
The create trigger option was set to true. We do not need to create these triggers as they are already being created by tekton pipeline chart.We are only adding bindings to those triggers