### PR TITLE
Remove EL PodTemplate

### DIFF
--- a/01-gabbar/00-tekton-pipelines/00-build/values.yaml
+++ b/01-gabbar/00-tekton-pipelines/00-build/values.yaml
@@ -115,11 +115,6 @@ stakater-tekton-chart:
           effect: "NoExecute"
   eventlistener:
     serviceAccountName: stakater-tekton-builder
-    podTemplate:
-      tolerations:
-        - key: "pipeline"
-          operator: "Exists"
-          effect: "NoExecute"
     triggers:
     - name: stakater-pr-cleaner-v2-pullrequest-merge
       create: false


### PR DESCRIPTION
Removing el podtemplate as it did not work as intended. The version of tekton that we have does not support PodTemplate key. It was only available for a specific version. This should be removed from tekton-chart as well